### PR TITLE
Upgrade Python version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 #
 # ********************************************************
 
-FROM python:3.8-slim-buster
+FROM python:3.11-slim-bookworm
 
 LABEL net.juniper.framework="NITA"
 


### PR DESCRIPTION
Old version no longer supported, apt-get errors out due to repository being empty.