### PR TITLE
Feature/harden variable import

### DIFF
--- a/robot-resources/variables_file/juniper_common.py
+++ b/robot-resources/variables_file/juniper_common.py
@@ -20,12 +20,18 @@ from os import walk
 def parse_ansible_vars(group_vars, host_vars):
     gf = []
     for (dirpath, dirnames, filenames) in walk(group_vars):
-        gf.extend(filenames)
+        gf.extend([
+            f for f in filenames
+            if f.endswith(".yaml") or f.endswith(".yml")
+        ])
         break
 
     hf = []
     for (dirpath, dirnames, filenames) in walk(host_vars):
-        hf.extend(filenames)
+        hf.extend([
+            f for f in filenames
+            if f.endswith(".yaml") or f.endswith(".yml")
+        ])
         break
 
     av = {}
@@ -34,12 +40,14 @@ def parse_ansible_vars(group_vars, host_vars):
         f = open(group_vars + "/" + i, "r")
         y = yaml.load(f, Loader=yaml.SafeLoader)
         f.close()
-        av['group_vars'][i] = y
+        if isinstance(y, dict):
+            av['group_vars'][i] = y
     av['host_vars'] = {}
     for i in hf:
         f = open(host_vars + "/" + i, "r")
         y = yaml.load(f, Loader=yaml.SafeLoader)
         f.close()
-        av['host_vars'][i] = y
+        if isinstance(y, dict):
+            av['host_vars'][i] = y
 
     return av

--- a/robot-resources/variables_file/variables.py
+++ b/robot-resources/variables_file/variables.py
@@ -45,14 +45,14 @@ password = av['group_vars']['all.yaml']['netconf_passwd']
 
 # set the management ip variables i.e. vmx1_mgmt_ip = "100.123.1.0"
 for key, value in iter(av['host_vars'].items()):
-    if 'management_interface' in value.keys():
+    if isinstance(value, dict) and 'management_interface' in value.keys():
         ip = value['management_interface']['ip']
         exec(key.replace("-", "_").replace(".yaml","") + '_mgmt_ip = "' + ip + '"')
 
 # core interface ip variables for use in tests
 # create ci_vmx1_ge_0_0_0, etc
 for key, value in iter(av['host_vars'].items()):
-    if 'core_interfaces' in value.keys():
+    if isinstance(value, dict) and 'core_interfaces' in value.keys():
         for i in value['core_interfaces']:
             hname = key.replace("-","_").replace(".yaml", "")
             iname = i['int'].replace("/","_").replace("-","_")


### PR DESCRIPTION
Currently if a non YAML file is present in either group_vars or host_vars then Robot test will fail when it attempts to parse the non-YAML file and cannot identify management_interface.  For example if group_vars contains a .gitkeep file or a README.md file etc.

This pull request hardens the process around reading the variables from the vars, and only checks for .yml or .yaml files, and also ensures that after yaml.SafeLoader has been called that the data is a dict.   Safe guards are also added to variables.py so that there are no "AttributeError: NoneType object has no attribute keys" when a non YAML file is present in group_vars or host_vars.